### PR TITLE
Travis-CI related files added

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+rvm:
+  - 1.9.2
+gemfile: gemfiles/Gemfile.travis
+notifications:
+  recipients:
+    - chris@dinarrr.com
+

--- a/Gemfile.travis
+++ b/Gemfile.travis
@@ -1,0 +1,6 @@
+source "http://rubygems.org"
+
+gem "rake" # added for travis-ci.org
+
+# Specify your gem's dependencies in testrocket.gemspec
+gemspec


### PR DESCRIPTION
If you also want to automatically test it with http://travis-ci.org/, then add this commit (and enable your repo in travis, too).

You can add your email address to the recipients part of `.travis.yml`.

I added an separate Gemfile for travis, because they explicitly need the rake gem in the bundle.
