### PR TITLE
Fixed an issue with redefining global Proc's ! method

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .bundle
 Gemfile.lock
 pkg/*
+.vscode

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Example
 
 ```ruby
 require 'testrocket'
+using TestRocket
 
 # BASIC USAGE
 # +-> { block that should succeed }
@@ -51,6 +52,8 @@ As well as running tests in separate test files in the 'traditional' way, TestRo
 
 ```ruby
 class YourClass
+  using TestRocket
+
   def initialize
   end
 

--- a/lib/testrocket.rb
+++ b/lib/testrocket.rb
@@ -1,35 +1,37 @@
+# frozen_string_literal: true
+
+##
+# TestRocket Module to refine lambdas an use them for lightweight tests
+#
 module TestRocket
-  VERSION = "0.1.0"
+  VERSION = '1.0.0'
 
   extend Module.new { attr_accessor :out }
 
-  module Live
-    def _test(a, b); send((call rescue()) ? a : b) end  
-    def _show(r); (TestRocket.out || STDERR) << r + "\n"; r end
-    def _pass; "     OK" end
-    def _fail; "   FAIL @ #{source_location * ':'}" end
-    def _pend; "PENDING '#{call}' @ #{source_location * ':'}" end
-    def _desc; "   FIRE '#{call}'!" end
+  refine Proc do
+    # Include TestRocket methods WITHOUT implementation selected
+    Proc.send :include, TestRocket
+
+    # If we're in a production environment, the tests shall do nothing.
+    if ENV['RACK_ENV'] == 'production' ||
+       (defined?(Rails) && Rails.env.production?) ||
+       ENV['RAILS_ENV'] == 'production'
+      def _test(a, b); end
+      def _show(r); end
+      def _pend; end
+      def _desc; end
+    else
+      def _test(a, b); send((call rescue()) ? a : b) end
+      def _show(r); (TestRocket.out || STDERR) << r + "\n"; r end
+      def _pass; '     OK' end
+      def _fail; "   FAIL @ #{source_location * ':'}" end
+      def _pend; "PENDING '#{call}' @ #{source_location * ':'}" end
+      def _desc; "   FIRE '#{call}'!" end
+    end
+
+    def +@; _show _test :_pass, :_fail end
+    def -@; _show _test :_fail, :_pass end
+    def ~; _show _pend end
+    def !; _show _desc end
   end
-
-  module Dummy
-    def _test(a, b); end
-    def _show(r); end
-    def _pend; end
-    def _desc; end
-  end
-
-  def +@; _show _test :_pass, :_fail end
-  def -@; _show _test :_fail, :_pass end
-  def ~; _show _pend end
-  def !; _show _desc end
-end
-
-Proc.send :include, TestRocket
-
-# If we're in a production environment, the tests shall do nothing.
-if ENV['RACK_ENV'] == 'production' || (defined?(Rails) && Rails.env.production?) || ENV['RAILS_ENV'] == 'production'
-  Proc.send :include, TestRocket::Dummy
-else
-  Proc.send :include, TestRocket::Live
 end

--- a/test/test_testrocket.rb
+++ b/test/test_testrocket.rb
@@ -29,21 +29,21 @@ class RefinementTest
       end
 
       it 'should give a pending notice' do
-        (~->{ "a pending test" }).must_match(/PENDING/)
-        (~->{ "a pending test" }).must_match(/a pending test/)
-        (~->{ "a pending test" }).must_match("#{__FILE__}:#{__LINE__}")
+        (~->{ 'a pending test' }).must_match(/PENDING/)
+        (~->{ 'a pending test' }).must_match(/a pending test/)
+        (~->{ 'a pending test' }).must_match("#{__FILE__}:#{__LINE__}")
       end
 
       it 'should fire a description rocket' do
-        (!->{ "a description" }).must_match(/FIRE/)
-        (!->{ "a description" }).must_match(/a description/)
+        (!->{ 'a description' }).must_match(/FIRE/)
+        (!->{ 'a description' }).must_match(/a description/)
       end
 
       it 'would influence Ruby Proc if TestRocket used explitly' do
         (
           ok = ->() { nil }
           !ok
-        ).must_equal("   FIRE ''!")
+        ).must_match(/FIRE/)
       end
     end
   end
@@ -52,7 +52,7 @@ end
 class NoRefinementTest
   def self.test!
     describe 'Without `using TestRocket`' do
-      it "should not influence global Ruby scope and other libs" do
+      it 'should not influence global Ruby scope and other libs' do
         (
           ok = ->() { nil }
           !ok

--- a/test/test_testrocket.rb
+++ b/test/test_testrocket.rb
@@ -1,37 +1,66 @@
 require_relative 'helper'
 
-describe TestRocket do
-  it "should find emptiness non-truthful by default" do
-    (+->{}).must_match(/FAIL/)
-    (+->{}).must_match("#{__FILE__}:#{__LINE__}")
-  end
-  
-  it "should pass a simple positive assertion" do
-    (+->{ 2 + 2 == 4 }).must_match(/OK/)
-  end
+class RefinementTest
+  using TestRocket
 
-  it "should pass a simple negative assertion" do
-    (-->{ 2 + 2 == 5 }).must_match(/OK/)
-  end
-  
-  it "should fail a simple erroneous assertion" do
-    (+->{ 2 + 2 == 5 }).must_match(/FAIL/)
-    (+->{ 2 + 2 == 5 }).must_match("#{__FILE__}:#{__LINE__}")
-  end
+  def self.test!
+    describe TestRocket do
+      it 'should find emptiness non-truthful by default' do
+        (+->{}).must_match(/FAIL/)
+        (+->{}).must_match("#{__FILE__}:#{__LINE__}")
+      end
 
-  it "should fail a simple correct assertion assumed to fail" do
-    (-->{ 2 + 2 == 4 }).must_match(/FAIL/)
-    (-->{ 2 + 2 == 4 }).must_match("#{__FILE__}:#{__LINE__}")
-  end
-  
-  it "should give a pending notice" do
-    (~->{ "a pending test" }).must_match(/PENDING/)
-    (~->{ "a pending test" }).must_match(/a pending test/)
-    (~->{ "a pending test" }).must_match("#{__FILE__}:#{__LINE__}")
-  end
-  
-  it "should fire a description rocket" do
-    (!->{ "a description" }).must_match(/FIRE/)
-    (!->{ "a description" }).must_match(/a description/)
+      it 'should pass a simple positive assertion' do
+        (+->{ 2 + 2 == 4 }).must_match(/OK/)
+      end
+
+      it 'should pass a simple negative assertion' do
+        (-->{ 2 + 2 == 5 }).must_match(/OK/)
+      end
+
+      it 'should fail a simple erroneous assertion' do
+        (+->{ 2 + 2 == 5 }).must_match(/FAIL/)
+        (+->{ 2 + 2 == 5 }).must_match("#{__FILE__}:#{__LINE__}")
+      end
+
+      it 'should fail a simple correct assertion assumed to fail' do
+        (-->{ 2 + 2 == 4 }).must_match(/FAIL/)
+        (-->{ 2 + 2 == 4 }).must_match("#{__FILE__}:#{__LINE__}")
+      end
+
+      it 'should give a pending notice' do
+        (~->{ "a pending test" }).must_match(/PENDING/)
+        (~->{ "a pending test" }).must_match(/a pending test/)
+        (~->{ "a pending test" }).must_match("#{__FILE__}:#{__LINE__}")
+      end
+
+      it 'should fire a description rocket' do
+        (!->{ "a description" }).must_match(/FIRE/)
+        (!->{ "a description" }).must_match(/a description/)
+      end
+
+      it 'would influence Ruby Proc if TestRocket used explitly' do
+        (
+          ok = ->() { nil }
+          !ok
+        ).must_equal("   FIRE ''!")
+      end
+    end
   end
 end
+
+class NoRefinementTest
+  def self.test!
+    describe 'Without `using TestRocket`' do
+      it "should not influence global Ruby scope and other libs" do
+        (
+          ok = ->() { nil }
+          !ok
+        ).must_equal(false)
+      end
+    end
+  end
+end
+
+RefinementTest.test!
+NoRefinementTest.test!

--- a/testrocket.gemspec
+++ b/testrocket.gemspec
@@ -6,13 +6,13 @@ Gem::Specification.new do |s|
   s.name        = 'testrocket'
   s.version     = TestRocket::VERSION
   s.platform    = Gem::Platform::RUBY
-  s.authors     = %w[Peter Cooper Christoph Grabo]
+  s.authors     = ['Peter Cooper', 'Christoph Grabo']
   s.email       = %w[git@peterc.org chris@dinarrr.com]
   s.homepage    = 'http://github.com/peterc/testrocket'
   s.summary     = %q{A super lightweight lamdba-based testing library for Ruby}
   s.description = %q{A super lightweight lamdba-based testing library for Ruby}
 
-  s.rubyforge_project = "testrocket"
+  s.rubyforge_project = 'testrocket'
 
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")

--- a/testrocket.gemspec
+++ b/testrocket.gemspec
@@ -1,14 +1,14 @@
 # -*- encoding: utf-8 -*-
-$:.push File.expand_path("../lib", __FILE__)
-require "testrocket"
+$:.push File.expand_path('../lib', __FILE__)
+require 'testrocket'
 
 Gem::Specification.new do |s|
-  s.name        = "testrocket"
+  s.name        = 'testrocket'
   s.version     = TestRocket::VERSION
   s.platform    = Gem::Platform::RUBY
-  s.authors     = ["Peter Cooper","Christoph Grabo"]
-  s.email       = ["git@peterc.org","chris@dinarrr.com"]
-  s.homepage    = "http://github.com/peterc/testrocket"
+  s.authors     = %w[Peter Cooper Christoph Grabo]
+  s.email       = %w[git@peterc.org chris@dinarrr.com]
+  s.homepage    = 'http://github.com/peterc/testrocket'
   s.summary     = %q{A super lightweight lamdba-based testing library for Ruby}
   s.description = %q{A super lightweight lamdba-based testing library for Ruby}
 
@@ -16,6 +16,6 @@ Gem::Specification.new do |s|
 
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
-  s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
-  s.require_paths = ["lib"]
+  s.executables   = `git ls-files -- bin/*`.split("\n").map { |f| File.basename(f) }
+  s.require_paths = ['lib']
 end


### PR DESCRIPTION
fix: an issue with proc's ! operator (https://is.gd/N0K9yn)
chore: bump the major version 0.1.0 → 1.0.0

Caught an issue using [json_schemer](https://github.com/davishmcclurg/json_schemer) which uses [ecma-re-validator](https://github.com/gjtorikian/ecma-re-validator), which depends on [pry-0.12.2](https://github.com/pry/pry) which uses ! on a block and unintentionally calls TestRocket's redefined version and crushes trying to use the result (`nil`).

Had to define TestRocket functionality through Ruby refinements to isolate the scope, therefore the usage changed and now it's necessary to use `using TestRocket` explicit syntax where using the tests. Hence the backwards compatibility is impossible and major version number bump was necessary (which was long expected anyway https://github.com/peterc/testrocket/issues/8).

Thanks for the project, really love it and would appreciate a fix and releasing this and other versions to https://rubygems.org and tagging the versions on GitHub. Thank you! 🙏
