### PR TITLE
Adjusts code for more readability

### DIFF
--- a/lib/testrocket.rb
+++ b/lib/testrocket.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 ##
-# TestRocket Module to refine lambdas an use them for lightweight tests
+# TestRocket Module to refine procs and use them for lightweight tests
 #
 module TestRocket
   VERSION = '1.0.0'


### PR DESCRIPTION
This PR is merely a suggestion on some improvements (IMO) on readability following some tips from the [ruby style guide](https://github.com/rubocop-hq/ruby-style-guide) as I had some difficulty reading the code in terms of space utilized.

Also made a change to extract a big conditional to a method: `production_env?`