### PR TITLE
Replace "extend Module.new" with "self.class.attr_accessor" for readability

### DIFF
--- a/lib/testrocket.rb
+++ b/lib/testrocket.rb
@@ -6,7 +6,7 @@
 module TestRocket
   VERSION = '1.0.0'
 
-  extend Module.new { attr_accessor :out }
+  self.class.attr_accessor :out
 
   refine Proc do
     # Include TestRocket methods WITHOUT implementation selected

--- a/test/test_testrocket.rb
+++ b/test/test_testrocket.rb
@@ -45,6 +45,18 @@ class RefinementTest
           !ok
         ).must_match(/FIRE/)
       end
+
+      it 'should set and get out value' do
+        original = TestRocket.out
+        require 'stringio'
+        io = StringIO.new
+        begin
+          TestRocket.out = io
+          (TestRocket.out).must_be_same_as io
+        ensure
+          TestRocket.out = original
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
`extend Module.new { attr_accessor :out }` is a little tricky. (I couldn't understand at first sight.) I think `self.class.attr_accessor :out` would be easier to read.