### PR TITLE
Cleans and fixes typos

### DIFF
--- a/test/test_testrocket.rb
+++ b/test/test_testrocket.rb
@@ -5,41 +5,41 @@ class RefinementTest
 
   def self.test!
     describe TestRocket do
-      it 'should find emptiness non-truthful by default' do
+      it 'finds emptiness non-truthful by default' do
         (+->{}).must_match(/FAIL/)
         (+->{}).must_match("#{__FILE__}:#{__LINE__}")
       end
 
-      it 'should pass a simple positive assertion' do
+      it 'passes a simple positive assertion' do
         (+->{ 2 + 2 == 4 }).must_match(/OK/)
       end
 
-      it 'should pass a simple negative assertion' do
+      it 'passes a simple negative assertion' do
         (-->{ 2 + 2 == 5 }).must_match(/OK/)
       end
 
-      it 'should fail a simple erroneous assertion' do
+      it 'fails a simple erroneous assertion' do
         (+->{ 2 + 2 == 5 }).must_match(/FAIL/)
         (+->{ 2 + 2 == 5 }).must_match("#{__FILE__}:#{__LINE__}")
       end
 
-      it 'should fail a simple correct assertion assumed to fail' do
+      it 'fails a simple correct assertion assumed to fail' do
         (-->{ 2 + 2 == 4 }).must_match(/FAIL/)
         (-->{ 2 + 2 == 4 }).must_match("#{__FILE__}:#{__LINE__}")
       end
 
-      it 'should give a pending notice' do
+      it 'gives a pending notice' do
         (~->{ 'a pending test' }).must_match(/PENDING/)
         (~->{ 'a pending test' }).must_match(/a pending test/)
         (~->{ 'a pending test' }).must_match("#{__FILE__}:#{__LINE__}")
       end
 
-      it 'should fire a description rocket' do
+      it 'fires a description rocket' do
         (!->{ 'a description' }).must_match(/FIRE/)
         (!->{ 'a description' }).must_match(/a description/)
       end
 
-      it 'would influence Ruby Proc if TestRocket used explitly' do
+      it 'influences Ruby Proc if TestRocket used explicitly' do
         (
           ok = ->() { nil }
           !ok
@@ -52,7 +52,7 @@ end
 class NoRefinementTest
   def self.test!
     describe 'Without `using TestRocket`' do
-      it 'should not influence global Ruby scope and other libs' do
+      it 'does not influence global Ruby scope and other libs' do
         (
           ok = ->() { nil }
           !ok

--- a/testrocket.gemspec
+++ b/testrocket.gemspec
@@ -9,8 +9,8 @@ Gem::Specification.new do |s|
   s.authors     = ['Peter Cooper', 'Christoph Grabo']
   s.email       = %w[git@peterc.org chris@dinarrr.com]
   s.homepage    = 'http://github.com/peterc/testrocket'
-  s.summary     = %q{A super lightweight lamdba-based testing library for Ruby}
-  s.description = %q{A super lightweight lamdba-based testing library for Ruby}
+  s.summary     = %q{A super lightweight lambda-based testing library for Ruby}
+  s.description = %q{A super lightweight lambda-based testing library for Ruby}
 
   s.rubyforge_project = 'testrocket'
 


### PR DESCRIPTION
Fixes some typos and changes should for 3rd person in present tense in specs, according to good practices listed in http://www.betterspecs.org/#should.
