### PR TITLE
remove old implements

### DIFF
--- a/lib/testrocket.rb
+++ b/lib/testrocket.rb
@@ -9,9 +9,6 @@ module TestRocket
   extend Module.new { attr_accessor :out }
 
   refine Proc do
-    # Include TestRocket methods WITHOUT implementation selected
-    Proc.send :include, TestRocket
-
     # If we're in a production environment, the tests shall do nothing.
     if ENV['RACK_ENV'] == 'production' ||
        (defined?(Rails) && Rails.env.production?) ||
@@ -22,7 +19,7 @@ module TestRocket
       def _desc; end
     else
       def _test(a, b); send((call rescue()) ? a : b) end
-      def _show(r); (TestRocket.out || STDERR) << r + "\n"; r end
+      def _show(r); (TestRocket.out || STDERR) << r + "\n" end
       def _pass; '     OK' end
       def _fail; "   FAIL @ #{source_location * ':'}" end
       def _pend; "PENDING '#{call}' @ #{source_location * ':'}" end


### PR DESCRIPTION
I think **testrocket** is really interesting idea. 
But there is some legacy code snippets.
It seems to be left behind in the flow of improvement.

### 1. remove useless retun value  
`def _show(r); (TestRocket.out || STDERR) << r + "\n"; r end`
That variable **"r"** was used when testrocket had been started to invent.
But it`s logic is changed, return value is not used now.

### 2. remove Proc.send
`Proc.send :include, TestRocket`
now **refine** and **using** works enough.
We don't have to load TestRocket module using send method.